### PR TITLE
gyakorikerdesek megint

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -1182,35 +1182,9 @@ prohardver.hu,mobilarena.hu,logout.hu,hardverapro.hu#?#div:not(.priv-thread-owne
 !-------------------------------------------------------------------------------!
 ||*/empty.json
 ||*/eu-banned-popup/
-
-!minden kép, gyakorikerdesek.hu
-||static.gyakorikerdesek.hu/*.png$image
-||static.gyakorikerdesek.hu/*.jpg$image
-||static.gyakorikerdesek.hu/*.jpeg$image
-||static.gyakorikerdesek.hu/*.bmp$image
-||static.gyakorikerdesek.hu/*.webp$image
-||static.gyakorikerdesek.hu/*.svg$image
-||static.gyakorikerdesek.hu/*.tiff$image
-||static.gyakorikerdesek.hu/*.tif$image
-||static.gyakorikerdesek.hu/*.gif$image
-||static.gyakorikerdesek.hu/*.tga$image
-||static.gyakorikerdesek.hu/*.ico$image
-||static.gyakorikerdesek.hu/*.avif$image
-
-!kivéve ikonok, gyakorikerdesek.hu
-@@||static.gyakorikerdesek.hu/p/*.png$image
-@@||static.gyakorikerdesek.hu/p/*.jpg$image
-@@||static.gyakorikerdesek.hu/p/*.jpeg$image
-@@||static.gyakorikerdesek.hu/p/*.bmp$image
-@@||static.gyakorikerdesek.hu/p/*.webp$image
-@@||static.gyakorikerdesek.hu/p/*.svg$image
-@@||static.gyakorikerdesek.hu/p/*.tiff$image
-@@||static.gyakorikerdesek.hu/p/*.tif$image
-@@||static.gyakorikerdesek.hu/p/*.gif$image
-@@||static.gyakorikerdesek.hu/p/*.tga$image
-@@||static.gyakorikerdesek.hu/p/*.ico$image
-@@||static.gyakorikerdesek.hu/p/*.avif$image
-
+||*$image,domain=gyakorikerdesek.hu
+||*$media,domain=gyakorikerdesek.hu
+@@||gyakorikerdesek.hu/p/$image
 ! https://github.com/hufilter/hufilter/issues/688
 ||rosszlanyok.hu/bannerek/$image
 ||partner.tippmixpro.hu/skins/tippmixpro/uploads/banners/

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -427,6 +427,9 @@ gyakorikerdesek.hu##.rltdwidget
 gyakorikerdesek.hu##IFRAME
 gyakorikerdesek.hu##[id*="aswift"]
 gyakorikerdesek.hu##td.txtcenter:has(>script+ins)
+gyakorikerdesek.hu##div[id] > a:empty[href]
+gyakorikerdesek.hu##div[id] > a:has-text(/^[\s\u00A0]*$/)
+gyakorikerdesek.hu##div[id] > div[style*="background-color"]
 gyaloglo.hu###banner
 gyaloglo.hu##div[class*="Advert"]
 gyartastrend.hu##[class*="contentBanner"]

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -1182,6 +1182,7 @@ prohardver.hu,mobilarena.hu,logout.hu,hardverapro.hu#?#div:not(.priv-thread-owne
 !-------------------------------------------------------------------------------!
 ||*/empty.json
 ||*/eu-banned-popup/
+
 ||*$image,domain=gyakorikerdesek.hu
 ||*$media,domain=gyakorikerdesek.hu
 @@||gyakorikerdesek.hu/p/$image

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -422,7 +422,6 @@ gportal.hu##[class*="banner"]
 gsplus.hu,pcwplus.hu##.ad
 gsplus.hu,pcwplus.hu##.box-wrapper > .box-actual-magazine + .box-html
 gumiszoba.com##.wpcnt
-gyakorikerdesek.hu,hoxa.hu##div[style="text-align: center; margin: 30px 0px;"]:has(> a)
 gyakorikerdesek.hu###adryf
 gyakorikerdesek.hu##.rltdwidget
 gyakorikerdesek.hu##IFRAME
@@ -1183,6 +1182,34 @@ prohardver.hu,mobilarena.hu,logout.hu,hardverapro.hu#?#div:not(.priv-thread-owne
 !-------------------------------------------------------------------------------!
 ||*/empty.json
 ||*/eu-banned-popup/
+
+!minden kép, gyakorikerdesek.hu
+||static.gyakorikerdesek.hu/*.png$image
+||static.gyakorikerdesek.hu/*.jpg$image
+||static.gyakorikerdesek.hu/*.jpeg$image
+||static.gyakorikerdesek.hu/*.bmp$image
+||static.gyakorikerdesek.hu/*.webp$image
+||static.gyakorikerdesek.hu/*.svg$image
+||static.gyakorikerdesek.hu/*.tiff$image
+||static.gyakorikerdesek.hu/*.tif$image
+||static.gyakorikerdesek.hu/*.gif$image
+||static.gyakorikerdesek.hu/*.tga$image
+||static.gyakorikerdesek.hu/*.ico$image
+||static.gyakorikerdesek.hu/*.avif$image
+
+!kivéve ikonok, gyakorikerdesek.hu
+@@||static.gyakorikerdesek.hu/p/*.png$image
+@@||static.gyakorikerdesek.hu/p/*.jpg$image
+@@||static.gyakorikerdesek.hu/p/*.jpeg$image
+@@||static.gyakorikerdesek.hu/p/*.bmp$image
+@@||static.gyakorikerdesek.hu/p/*.webp$image
+@@||static.gyakorikerdesek.hu/p/*.svg$image
+@@||static.gyakorikerdesek.hu/p/*.tiff$image
+@@||static.gyakorikerdesek.hu/p/*.tif$image
+@@||static.gyakorikerdesek.hu/p/*.gif$image
+@@||static.gyakorikerdesek.hu/p/*.tga$image
+@@||static.gyakorikerdesek.hu/p/*.ico$image
+@@||static.gyakorikerdesek.hu/p/*.avif$image
 
 ! https://github.com/hufilter/hufilter/issues/688
 ||rosszlanyok.hu/bannerek/$image


### PR DESCRIPTION
Annak aki idetéved, bemásolom az összes szabályt ami most működik:
```
gyakorikerdesek.hu##div[id] > a:empty[href]
gyakorikerdesek.hu##div[id] > a:has-text(/^[\s\u00A0]*$/)
gyakorikerdesek.hu##div[id] > div[style*="background-color"]
||*$image,domain=gyakorikerdesek.hu
||*$media,domain=gyakorikerdesek.hu
@@||gyakorikerdesek.hu/p/$image
```

---
Ez nem fogja meg az összes hirdetést. A főoldalon működik, azt láttam.
(Update: Már ott sem...)
Felesleges ennyire specifikálni, mert azonnal át fogják írni.

`gyakorikerdesek.hu,hoxa.hu##div[style="text-align: center; margin: 30px 0px;"]:has(> a)`

Napi szinten lassan 5x írják át az oldalt.
Nem értem, miért nem lehet letiltani az összes képet, mikor nincs szükségünk a képekre, kivéve az ikonokat.
Lassan több időt töltök itt mint a munkában, mikor egyszerűen csak ki kéne tiltani az összes képet és akkor írhatnák át nyugodtan az oldalt ahogy akarják.

Ez tesztelve van és működik.