### PR TITLE
foodora videó reklám

### DIFF
--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -390,6 +390,7 @@ figyelo.hu##[class*="adbox"]
 figyelo.hu##[class*="banner"]
 filmoldal.hu##div[class*="reklam"]
 foodora.hu##.partnership-ads
+foodora.hu##div[class*="video-container"]
 forbes.hu##div[id^="forbesad"]
 forbes.hu##p + [class*="-bekezdes-utan-"]
 forum.index.hu###ot2015


### PR DESCRIPTION
a rendelés követő oldalon jön be néha videó reklám
többször is találkoztam vele, mobilneten különösen lassíthatja a kapcsolatot

https://www.foodora.hu/order-tracking/<rendeles_ID>