### PR TITLE
gyakorikerdesek.hu üres reklám diveket szűrő cucc + hoxa új szabályok

### DIFF
--- a/sections/adguard-specific/ads.txt
+++ b/sections/adguard-specific/ads.txt
@@ -9,8 +9,8 @@
 !-------------------------------------------------------------------------------!
 hoxa.hu#?#a:matches-css(background: /url.*/)
 hoxa.hu#?#a:matches-css(background-image: /url.*/)
-gyakorikerdesek.hu#?#a:matches-css(background: /url.*/):not(:matches-css(background: /url.*/static\.gyakorikerdesek\.hu\/p\//))
-gyakorikerdesek.hu#?#a:matches-css(background-image: /url.*/):not(:matches-css(background-image: /url.*/static\.gyakorikerdesek\.hu\/p\//))
+gyakorikerdesek.hu#?#a:matches-css(background: /url(?!.*static\.gyakorikerdesek\.hu\/p\/).*/)
+gyakorikerdesek.hu#?#a:matches-css(background-image: /url(?!.*static\.gyakorikerdesek\.hu\/p\/).*/)
 ! https://github.com/uBlockOrigin/uAssets/issues/23271
 jofogas.hu#%#//scriptlet('prevent-setTimeout', 'E(!1)')
 myonlineradio.hu#$#._bannerTop1 { background-color: transparent !important; }

--- a/sections/adguard-specific/ads.txt
+++ b/sections/adguard-specific/ads.txt
@@ -9,6 +9,8 @@
 !-------------------------------------------------------------------------------!
 hoxa.hu#?#a:matches-css(background: /url.*/)
 hoxa.hu#?#a:matches-css(background-image: /url.*/)
+gyakorikerdesek.hu#?#a:matches-css(background: /url.*/):not(:matches-css(background: /url.*/static\.gyakorikerdesek\.hu\/p\//))
+gyakorikerdesek.hu#?#a:matches-css(background-image: /url.*/):not(:matches-css(background-image: /url.*/static\.gyakorikerdesek\.hu\/p\//))
 ! https://github.com/uBlockOrigin/uAssets/issues/23271
 jofogas.hu#%#//scriptlet('prevent-setTimeout', 'E(!1)')
 myonlineradio.hu#$#._bannerTop1 { background-color: transparent !important; }

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -509,6 +509,8 @@ hogymondom.hu##img[src*="ads"]
 hogymondom.hu##td > a > img[data-src]
 hogymondom.hu##td > a[href*="utm_campaign"]
 hotdog.hu###tetszett
+hoxa.hu##img
+hoxa.hu##div>a:has(img)
 hrportal.hu##.ui-widget-overlay
 hrportal.hu##[class*="banner"]
 hrportal.hu###cucc

--- a/sections/ublock-origin-specific/ads.txt
+++ b/sections/ublock-origin-specific/ads.txt
@@ -9,8 +9,8 @@
 !-------------------------------------------------------------------------------!
 hoxa.hu##a:matches-css(background: /url.*/)
 hoxa.hu##a:matches-css(background-image: /url.*/)
-gyakorikerdesek.hu##a:matches-css(background: /url.*/):not(:matches-css(background: /url.*/static\.gyakorikerdesek\.hu\/p\//))
-gyakorikerdesek.hu##a:matches-css(background-image: /url.*/):not(:matches-css(background-image: /url.*/static\.gyakorikerdesek\.hu\/p\//))
+gyakorikerdesek.hu##a:matches-css(background: /url(?!.*static\.gyakorikerdesek\.hu\/p\/).*/)
+gyakorikerdesek.hu##a:matches-css(background-image: /url(?!.*static\.gyakorikerdesek\.hu\/p\/).*/)
 444.hu##article:has(a[href*="hirdetes"])
 444.hu##div.item:has(a[href*="hirdetes"])
 ! https://github.com/uBlockOrigin/uAssets/issues/23271

--- a/sections/ublock-origin-specific/ads.txt
+++ b/sections/ublock-origin-specific/ads.txt
@@ -9,6 +9,8 @@
 !-------------------------------------------------------------------------------!
 hoxa.hu##a:matches-css(background: /url.*/)
 hoxa.hu##a:matches-css(background-image: /url.*/)
+gyakorikerdesek.hu##a:matches-css(background: /url.*/):not(:matches-css(background: /url.*/static\.gyakorikerdesek\.hu\/p\//))
+gyakorikerdesek.hu##a:matches-css(background-image: /url.*/):not(:matches-css(background-image: /url.*/static\.gyakorikerdesek\.hu\/p\//))
 444.hu##article:has(a[href*="hirdetes"])
 444.hu##div.item:has(a[href*="hirdetes"])
 ! https://github.com/uBlockOrigin/uAssets/issues/23271


### PR DESCRIPTION
gyakorikerdesek.hu üres reklám diveket szűrő cucc.

Az előző szabály `gyakorikerdesek.hu##a[rel]:matches-css(background: /url.*static/)`
helyett a mostani stabilabb, mert ha a `rel`-t törlik, úgy szűrne minden képet.
(bár kicsit hosszabb, így ami kell kép, azt nem rejti el...)

Az előzőnél nem vettem figyelembe, hogy az üres divek megjelennek, ha nincsenek szűrve, hiába van letiltva az összes kép.

`background` és `background-image` szabályt is tettem bele, ki tudja mikor akarják változtatni.

<img width="1107" height="571" alt="kép" src="https://github.com/user-attachments/assets/92902111-23b8-4887-8042-b0b354b99746" />

---

Mostanában a szűrők nagyon lassan frissülnek.

Firefox alatt használom, ez az elsődleges forrás
https://cdn.jsdelivr.net/gh/hufilter/hufilter@gh-pages/hufilter-ublock.txt

Ezek a listák gyorsabban frissülnek, de a böngésző nem innen tölti.
https://raw.githubusercontent.com/hufilter/hufilter/refs/heads/gh-pages/hufilter-ublock.txt
https://filters.hufilter.hu/hufilter-ublock.txt

Ezt meg lehet változtatni nálam lokálisan, hogy honnan töltse?
Vagy vajon mi lehet a probléma, hogy nagyon lassan frissül az elsődleges forrás?