### PR TITLE
speedshop.hu

### DIFF
--- a/sections/adguard-specific/ads.txt
+++ b/sections/adguard-specific/ads.txt
@@ -7,6 +7,7 @@
 !-------------------------------------------------------------------------------!
 !------ Specific cosmetic filters ----------------------------------------------!
 !-------------------------------------------------------------------------------!
+speedshop.hu#%#//scriptlet('set-constant', 'exitpopup_overlay', 'noopFunc')
 liked.hu$$#liked-ad-systems-script
 
 liked.hu#%#//scriptlet('set-constant', 'showVignette', 'falseFunc')

--- a/sections/adguard-specific/ads.txt
+++ b/sections/adguard-specific/ads.txt
@@ -26,8 +26,6 @@ dehir.hu#$##popupFrontPageBanner-modal { display: none !important; }
 dehir.hu#$#body { overflow: auto !important; }
 prohardver.hu,fototrend.hu#$#main { background-image: none !important; }
 indavideo.hu#$#.promo { background: none !important; }
-speedshop.hu##body { position:static !important; overflow:auto !important; }
-speedshop.hu##* { filter: none !important; }
 
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
 ! https://github.com/hufilter/hufilter/issues/440, https://github.com/hufilter/hufilter/pulls/452

--- a/sections/adguard-specific/ads.txt
+++ b/sections/adguard-specific/ads.txt
@@ -26,6 +26,8 @@ dehir.hu#$##popupFrontPageBanner-modal { display: none !important; }
 dehir.hu#$#body { overflow: auto !important; }
 prohardver.hu,fototrend.hu#$#main { background-image: none !important; }
 indavideo.hu#$#.promo { background: none !important; }
+speedshop.hu##body { position:static !important; overflow:auto !important; }
+speedshop.hu##* { filter: none !important; }
 
 !#if (adguard_ext_safari || adguard_app_ios || adguard_ext_android_cb)
 ! https://github.com/hufilter/hufilter/issues/440, https://github.com/hufilter/hufilter/pulls/452

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -984,6 +984,8 @@ roadster.hu##.lead-ad-wrap
 romnet.hu##[class*="hirdetes"]
 romnet.hu##[id*="banner"]
 romnet.hu##[id*="hirdetes"]
+speedshop.hu###page_PopupContainer
+speedshop.hu###exposeMaskExitpopup
 sg.hu##.std0
 sg.hu##[class*="advert"]
 sg.hu##IMG[src="images/hirdetes.gif"]

--- a/sections/ads.txt
+++ b/sections/ads.txt
@@ -985,8 +985,6 @@ roadster.hu##.lead-ad-wrap
 romnet.hu##[class*="hirdetes"]
 romnet.hu##[id*="banner"]
 romnet.hu##[id*="hirdetes"]
-speedshop.hu###page_PopupContainer
-speedshop.hu###exposeMaskExitpopup
 sg.hu##.std0
 sg.hu##[class*="advert"]
 sg.hu##IMG[src="images/hirdetes.gif"]

--- a/sections/ublock-origin-specific/ads.txt
+++ b/sections/ublock-origin-specific/ads.txt
@@ -28,6 +28,8 @@ dehir.hu###popupFrontPageBanner-modal:style(display: none !important;)
 dehir.hu##body:style(overflow: auto !important;)
 prohardver.hu,fototrend.hu##main:style(background-image: none !important;)
 indavideo.hu##.promo:style(background: none !important;)
+speedshop.hu##body:style(position:static !important; overflow:auto !important;)
+speedshop.hu##*:style(filter: none !important;)
 
 !-------------------------------------------------------------------------------!
 !------ Specific network filters -----------------------------------------------!

--- a/sections/ublock-origin-specific/ads.txt
+++ b/sections/ublock-origin-specific/ads.txt
@@ -7,6 +7,7 @@
 !-------------------------------------------------------------------------------!
 !------ Specific cosmetic filters ----------------------------------------------!
 !-------------------------------------------------------------------------------!
+speedshop.hu##+js(set, exitpopup_overlay, noopFunc)
 liked.hu##^#liked-ad-systems-script
 
 liked.hu##+js(set, showVignette, falseFunc)

--- a/sections/ublock-origin-specific/ads.txt
+++ b/sections/ublock-origin-specific/ads.txt
@@ -28,8 +28,6 @@ dehir.hu###popupFrontPageBanner-modal:style(display: none !important;)
 dehir.hu##body:style(overflow: auto !important;)
 prohardver.hu,fototrend.hu##main:style(background-image: none !important;)
 indavideo.hu##.promo:style(background: none !important;)
-speedshop.hu##body:style(position:static !important; overflow:auto !important;)
-speedshop.hu##*:style(filter: none !important;)
 
 !-------------------------------------------------------------------------------!
 !------ Specific network filters -----------------------------------------------!


### PR DESCRIPTION
Az oldal megnyitása után pár mp-el jön egy popup és el blur-ol mindent.

Elég a `#ud_shop_start` elemről eltávolítani a `scroll-lock`-ot a `class` propertyből és megoldódik minden + a popupot eltávolítani.

Próbáltam letiltani a scriptet is, de eltöri az oldalt:
`||www.speedshop.hu/temp/shop_13890_001929d4b34124eeea59d4174b26f260.js$script,domain=www.speedshop.hu`

Igazából selfpromo lenne de nincs külön motorokra a fájl.
A megvalósításban és a kompatibilitásban nem vagyok biztos, de uBlock-on működik.
